### PR TITLE
Changed 'path' type to array from number

### DIFF
--- a/src/HealthGraph/abstract.json
+++ b/src/HealthGraph/abstract.json
@@ -123,7 +123,7 @@
                     "location": "json"
                 },
                 "path": {
-                    "type": "number",
+                    "type": "array",
                     "location": "json"
                 },
                 "post_to_facebook": {


### PR DESCRIPTION
Going off of the [RK API docs](http://developer.runkeeper.com/healthgraph/fitness-activities#Newly-Completed Activities), "path" should be an array.
